### PR TITLE
Allow whitespace between amount and currency

### DIFF
--- a/convert.rb
+++ b/convert.rb
@@ -16,7 +16,7 @@ units = data['units']
 if hasARGV
     str = ARGV[0].lstrip.gsub('$', 'usd').gsub('￥', 'cny').gsub('¥', 'jpy').gsub('£', 'gbp').gsub('€', 'eur')
     num = str.match(/^\d+/)
-    cy = str.match(/[a-zA-Z]{3}/)
+    cy = str.match(/\s*[a-zA-Z]{3}/)
     if str.empty? || num.nil? || cy.nil?
         temp = Hash[
             "title" => 'No result',
@@ -27,7 +27,7 @@ if hasARGV
         output["items"].push(temp)
     else
         num = num[0]
-        cy = cy[0].upcase
+        cy = cy[0].lstrip.upcase
         uri = URI("http://api.fixer.io/latest?base=#{cy}&symbols=#{units.join(',')}")
         result = JSON.parse(Net::HTTP.get(uri))
         result['rates'].each do |key, value|

--- a/convert.rb
+++ b/convert.rb
@@ -4,7 +4,7 @@ require 'json'
 
 hasARGV = false
 
-if !ARGV.empty? 
+if !ARGV[0].empty?
     hasARGV = true
 end
 

--- a/info.plist
+++ b/info.plist
@@ -123,7 +123,7 @@
 				<key>runningsubtext</key>
 				<string>connecting server....</string>
 				<key>script</key>
-				<string>LANG=en_US.UTF-8 /usr/bin/ruby ./convert.rb {query}</string>
+				<string>LANG=en_US.UTF-8 /usr/bin/ruby ./convert.rb "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
The query needs to be quoted when calling the ruby script from Alfred, and in the script we only need to match whitespace in the regex and strip the whitespace before converting the currency to upper-case.

Fixes #3