### PR TITLE
add support '$22'

### DIFF
--- a/convert.rb
+++ b/convert.rb
@@ -20,7 +20,7 @@ if hasARGV
     num = nil
     target = nil
     if to.nil?
-        num = str.match(/^\d+(.\d+)?/)
+        num = str.match(/\d+(.\d+)?/)
         if !num.nil?
             num = num[0]
         end


### PR DESCRIPTION
It was only support the format of '22$' because the re match num from the beginning of str, so I remove the '^' to let it can match like '$22'.